### PR TITLE
INTYGFV-12180: Förbättrad hantering av beräknings-statusen i redis

### DIFF
--- a/service/src/main/java/se/inera/statistics/service/caching/Cache.java
+++ b/service/src/main/java/se/inera/statistics/service/caching/Cache.java
@@ -200,6 +200,10 @@ public class Cache {
         return lookup(NATIONAL_DATA + "VALUES", supplier);
     }
 
+    /**
+     * @param isOngoing true if calculation should be started or false if calculation is done
+     * @return true if National data calculation was already ongoing, otherwise false
+     */
     public synchronized boolean getAndSetNationaldataCalculationOngoing(boolean isOngoing) {
         LOG.info("Getting and setting ongoing national data calculation");
 
@@ -208,11 +212,11 @@ public class Cache {
         final String key = NATIONAL_DATA + "ONGOING_CALCULATION";
         if (!isOngoing) {
             template.delete(key);
-            return false;
+            return true;
         }
 
-        final Object existingValue = ops.getAndSet(key, isOngoing);
-        if (existingValue == null) {
+        final Boolean didWriteNewValue = ops.setIfAbsent(key, true);
+        if (didWriteNewValue) {
             template.expire(key, ONE_HOUR_IN_MILLIS, TimeUnit.MILLISECONDS);
             return false;
         }


### PR DESCRIPTION
Det verkar inte som att ops.getAndSet någonstin returnerar null (utan istället något annat serialiserat objekt även när inget tidigare nyckelvärde existerar). Därför sattes aldrig något expire-värde i redis. Den här lösningen borde fungera bättre. Fr.o.m. v2.1 av redistemplate så fanns även en metod för att sätta expire-timout direkt i setIfAbsent, men det här borde fungera lika bra.