### PR TITLE
feature/INTYGFV-13280

### DIFF
--- a/test/src/test/protractor/dev/pages/filter.po.js
+++ b/test/src/test/protractor/dev/pages/filter.po.js
@@ -42,6 +42,7 @@ var Filter = function() {
   this.enhetBtn = this.container.element(by.css('.select-business button'));
   this.enhetDepth1List = this.dialog.all(by.css('.depth1'));
   this.enhetDepth2List = this.dialog.all(by.css('.depth2'));
+  this.enhetDepth3List = this.dialog.all(by.css('.depth3'));
   this.enhetCloseBtn = element(by.id('treeMultiSelectorCloseBtn'));
   this.enhetSaveAndCloseBtn = element(by.id('treeMultiSelectorSaveBtn'));
 

--- a/test/src/test/protractor/dev/specs/verksamhet/filter.spec.js
+++ b/test/src/test/protractor/dev/specs/verksamhet/filter.spec.js
@@ -130,8 +130,9 @@ describe('Verksamhetsfilter: ', function() {
       filter.enhetBtn.click();
 
       filter.enhetDepth1List.first().click();
+      filter.enhetDepth2List.first().click();
 
-      var first = filter.enhetDepth2List.first();
+      var first = filter.enhetDepth3List.first(); //
       enhet = first.getText();
 
       first.element(by.css('input')).click();

--- a/test/src/test/protractor/dev/specs/verksamhet/filter.spec.js
+++ b/test/src/test/protractor/dev/specs/verksamhet/filter.spec.js
@@ -132,7 +132,7 @@ describe('Verksamhetsfilter: ', function() {
       filter.enhetDepth1List.first().click();
       filter.enhetDepth2List.first().click();
 
-      var first = filter.enhetDepth3List.first(); //
+      var first = filter.enhetDepth3List.first();
       enhet = first.getText();
 
       first.element(by.css('input')).click();

--- a/web/src/main/webapp/app/shared/businessfilter/businessFilterFactory.js
+++ b/web/src/main/webapp/app/shared/businessfilter/businessFilterFactory.js
@@ -106,7 +106,6 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
   };
 
   businessFilter.selectGeographyBusiness = function(businessIds) {
-    //businessFilter.selectByAttribute(businessFilter.geography, businessIds, 'id');
     businessFilter.selectGeographyByAttribute(businessFilter.geography, businessIds, 'id');
     businessFilter.geographyBusinessIds = businessIds;
     treeMultiSelectorUtil.updateSelectionState(businessFilter.geography);
@@ -289,29 +288,17 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
       var existingVardenhetInFilter = _.find(munip.subs, {id: business.vardenhet ? business.id : business.vardenhetId});
 
       if (business.vardenhet && !existingVardenhetInFilter) {
-        //if (business.vardenhetId) {
-          munip.subs.push({
-            id: business.id,
-            numericalId: business.id + 'vardenhet',
-            name: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
-            visibleName: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
-            subs: [business]
-            //id: business.id,
-            //numericalId: business.id + 'vardenhet',
-            //name: business.name,
-            //visibleName: business.visibleName,
-            //subs: []
-          });
-       // }
-      //} else if (business.vardenhet && existingVardenhetInFilter) {
+        munip.subs.push({
+          id: business.id,
+          numericalId: business.id + 'vardenhet',
+          name: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
+          visibleName: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
+          subs: [business]
+        });
       } else if (business.vardenhet && existingVardenhetInFilter) {
-        //if (business.vardenhetId) {
-          //existingVardenhetInFilter.name = business.name;
-          //existingVardenhetInFilter.visibleName = business.visibleName;
-          existingVardenhetInFilter.name = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
-          existingVardenhetInFilter.visibleName = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
-          existingVardenhetInFilter.subs.push(business);
-        //}
+        existingVardenhetInFilter.name = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
+        existingVardenhetInFilter.visibleName = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
+        existingVardenhetInFilter.subs.push(business);
       } else if (!business.vardenhet && existingVardenhetInFilter) {
         existingVardenhetInFilter.subs.push(business);
       } else {
@@ -427,7 +414,7 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
       if (node.allSelected || node.someSelected) {
         return _.reduce(node.subs, function(acc, item) {
           return acc.concat(businessFilter.collectGeographyIds(item));
-        }, [] /*node.allSelected ? [node.id] : []*/);
+        }, []);
       } else {
         return [];
       }

--- a/web/src/main/webapp/app/shared/businessfilter/businessFilterFactory.js
+++ b/web/src/main/webapp/app/shared/businessfilter/businessFilterFactory.js
@@ -106,7 +106,8 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
   };
 
   businessFilter.selectGeographyBusiness = function(businessIds) {
-    businessFilter.selectByAttribute(businessFilter.geography, businessIds, 'id');
+    //businessFilter.selectByAttribute(businessFilter.geography, businessIds, 'id');
+    businessFilter.selectGeographyByAttribute(businessFilter.geography, businessIds, 'id');
     businessFilter.geographyBusinessIds = businessIds;
     treeMultiSelectorUtil.updateSelectionState(businessFilter.geography);
   };
@@ -288,16 +289,29 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
       var existingVardenhetInFilter = _.find(munip.subs, {id: business.vardenhet ? business.id : business.vardenhetId});
 
       if (business.vardenhet && !existingVardenhetInFilter) {
-        munip.subs.push({
-          id: business.id,
-          numericalId: business.id + 'vardenhet',
-          name: business.name,
-          visibleName: business.visibleName,
-          subs: []
-        });
+        //if (business.vardenhetId) {
+          munip.subs.push({
+            id: business.id,
+            numericalId: business.id + 'vardenhet',
+            name: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
+            visibleName: business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id,
+            subs: [business]
+            //id: business.id,
+            //numericalId: business.id + 'vardenhet',
+            //name: business.name,
+            //visibleName: business.visibleName,
+            //subs: []
+          });
+       // }
+      //} else if (business.vardenhet && existingVardenhetInFilter) {
       } else if (business.vardenhet && existingVardenhetInFilter) {
-        existingVardenhetInFilter.name = business.name;
-        existingVardenhetInFilter.visibleName = business.visibleName;
+        //if (business.vardenhetId) {
+          //existingVardenhetInFilter.name = business.name;
+          //existingVardenhetInFilter.visibleName = business.visibleName;
+          existingVardenhetInFilter.name = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
+          existingVardenhetInFilter.visibleName = business.vardenhetId && business.vardenhet ? business.vardenhetId : business.id;
+          existingVardenhetInFilter.subs.push(business);
+        //}
       } else if (!business.vardenhet && existingVardenhetInFilter) {
         existingVardenhetInFilter.subs.push(business);
       } else {
@@ -376,6 +390,22 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
     }
   };
 
+  businessFilter.selectGeographyByAttribute = function(item, listOfIdsToSelect, attribute) {
+    if (_.some(listOfIdsToSelect, function(val) {
+      return item[attribute] === val;
+    })) {
+      if (!item.subs) {
+        businessFilter.selectAll(item);
+      }
+    } else {
+      if (item.subs) {
+        _.each(item.subs, function(sub) {
+          businessFilter.selectGeographyByAttribute(sub, listOfIdsToSelect, attribute);
+        });
+      }
+    }
+  };
+
   businessFilter.selectByAttribute = function(item, listOfIdsToSelect, attribute) {
     if (_.some(listOfIdsToSelect, function(val) {
       return item[attribute] === val;
@@ -397,7 +427,7 @@ function createBusinessFilter(statisticsData, _, treeMultiSelectorUtil, moment, 
       if (node.allSelected || node.someSelected) {
         return _.reduce(node.subs, function(acc, item) {
           return acc.concat(businessFilter.collectGeographyIds(item));
-        }, node.allSelected ? [node.id] : []);
+        }, [] /*node.allSelected ? [node.id] : []*/);
       } else {
         return [];
       }

--- a/web/src/main/webapp/app/shared/treemultiselector/modal/modal.html
+++ b/web/src/main/webapp/app/shared/treemultiselector/modal/modal.html
@@ -13,15 +13,13 @@
             <span>{{directiveScope.selectAllTextKey | messageFilter}}</span>
           </label>
 
-          <!--Due to non-optimal functioning of the quick selection buttons for 'verksamhetstyp', this button is currently hidden
-            (by ng-hide set to true), which renders the quick selection buttons inaccessible from the GUI.-->
-          <button ng-if="directiveScope.sidebarMenuExpand" ng-hide="true" class="btn btn-link btn-link-minimal toggle-sidebar-link" ng-click="directiveScope.sidebarState.collapsed = !directiveScope.sidebarState.collapsed" ng-switch="directiveScope.sidebarState.collapsed">
-                                    <span ng-switch-when="true">
-                                        <span message key="{{directiveScope.sidebarMenuExpand}}" class="ellipsis-text"></span><i class="fa fa-chevron-right"></i>
-                                    </span>
+          <button ng-if="directiveScope.sidebarMenuExpand" class="btn btn-link btn-link-minimal toggle-sidebar-link" ng-click="directiveScope.sidebarState.collapsed = !directiveScope.sidebarState.collapsed" ng-switch="directiveScope.sidebarState.collapsed">
+            <span ng-switch-when="true">
+                <span message key="{{directiveScope.sidebarMenuExpand}}" class="ellipsis-text"></span><i class="fa fa-chevron-right"></i>
+            </span>
             <span ng-switch-when="false">
-                                      <span message key="{{directiveScope.sidebarMenuCollapse}}" class="ellipsis-text"></span><i class="fa fa-chevron-left"></i>
-                                    </span>
+                <span message key="{{directiveScope.sidebarMenuCollapse}}" class="ellipsis-text"></span><i class="fa fa-chevron-left"></i>
+            </span>
           </button>
 
         </div>

--- a/web/src/main/webapp/app/shared/treemultiselector/modal/modal.html
+++ b/web/src/main/webapp/app/shared/treemultiselector/modal/modal.html
@@ -12,7 +12,10 @@
             <input type="checkbox" ng-checked="directiveScope.menuOptions.allSelected" id="select-all-diagnoses" class="multiMenuSelectAll" ng-click="itemClicked(directiveScope.menuOptions)" />
             <span>{{directiveScope.selectAllTextKey | messageFilter}}</span>
           </label>
-          <button ng-if="directiveScope.sidebarMenuExpand" class="btn btn-link btn-link-minimal toggle-sidebar-link" ng-click="directiveScope.sidebarState.collapsed = !directiveScope.sidebarState.collapsed" ng-switch="directiveScope.sidebarState.collapsed">
+
+          <!--Due to non-optimal functioning of the quick selection buttons for 'verksamhetstyp', this button is currently hidden
+            (by ng-hide set to true), which renders the quick selection buttons inaccessible from the GUI.-->
+          <button ng-if="directiveScope.sidebarMenuExpand" ng-hide="true" class="btn btn-link btn-link-minimal toggle-sidebar-link" ng-click="directiveScope.sidebarState.collapsed = !directiveScope.sidebarState.collapsed" ng-switch="directiveScope.sidebarState.collapsed">
                                     <span ng-switch-when="true">
                                         <span message key="{{directiveScope.sidebarMenuExpand}}" class="ellipsis-text"></span><i class="fa fa-chevron-right"></i>
                                     </span>


### PR DESCRIPTION
NOTE that this work, on jira INTYGFV-13280, was performed in a local branch named feature/INTYGFV-13192 due to accidental continuation of work in the branch used for my previous jira (the work on which involved the same component, and now being intentionally canceled out by current changes).  Work now submitted includes re-insertion of the button for displaying quick-filter-buttons for 'verksamhetstyp' and fix of the tree-selection component by having it always display the level for 'vårdenehet', which in turn normalizes the function of the quick-filter-buttons. The extra level in the selection-tree  caused a few (3) protractor tests involving the changed component to fail. This was solved by adjusting the test to expect the vårdenhet-level. When approved this work should me merged to branch release/2020-3.